### PR TITLE
Refactor construction of the SUM query

### DIFF
--- a/lib/active_reporting/report.rb
+++ b/lib/active_reporting/report.rb
@@ -123,7 +123,6 @@ module ActiveReporting
         outer_select = "#{outer_columns.join(', ')}"
 
         # Finally, construct the query we want and return it as a string
-        puts "SELECT #{outer_select} FROM(#{inner_select} FROM #{inner_from}) AS T GROUP BY #{group_by}" # XXXXXXX TEMP FOR TESTING REMOVE
         "SELECT #{outer_select} FROM(#{inner_select} FROM #{inner_from}) AS T GROUP BY #{group_by}"
 
       else

--- a/lib/active_reporting/report.rb
+++ b/lib/active_reporting/report.rb
@@ -100,7 +100,12 @@ module ActiveReporting
         group_by = outer_group_by_statement.join(', ')
 
         # Finally, construct the query we want and return it as a string
-        "SELECT #{outer_columns} FROM(SELECT #{distinct}, #{inner_columns} FROM #{inner_from}) AS T GROUP BY #{group_by}"
+        full_statement = "SELECT #{outer_columns} FROM(SELECT #{distinct}, #{inner_columns} FROM #{inner_from}) AS T"
+
+        # Add the GROUP BY clause only if it's non nil and non empty
+        full_statement = "#{full_statement} GROUP BY #{group_by}" if group_by.present?
+
+        full_statement
 
       else
         parts = {

--- a/lib/active_reporting/report.rb
+++ b/lib/active_reporting/report.rb
@@ -123,29 +123,11 @@ module ActiveReporting
       end
     end
 
-    # Helper to merge two lists of columns into a single SELECT statement
-    # SQL does not permit duplicate column names within a select
-    #
-    #def merge_column_lists(list1, list2)
-    #  (list1 + list2).uniq
-    #end
-
     def select_statement
       ss = ["#{select_aggregate} AS #{@metric.name}"]
       ss += @dimensions.map { |d| d.select_statement(with_identifier: @dimension_identifiers) }
       ss.flatten
     end
-
-    #def outer_select_statement
-    #  ss = ["#{select_aggregate} AS #{@metric.name}"]
-    #  ss += @dimensions.map { |d| d.select_statement_no_rename(with_identifier: @dimension_identifiers) }
-    #  ss.flatten
-    #end
-
-    #def inner_select_statement
-    #  ss = @dimensions.map { |d| d.select_statement_always_rename(with_identifier: @dimension_identifiers) }
-    #  ss.flatten
-    #end
 
     def distinct
       "DISTINCT `#{@metric.model.name_without_component.downcase.pluralize}`.`id`"

--- a/lib/active_reporting/reporting_dimension.rb
+++ b/lib/active_reporting/reporting_dimension.rb
@@ -81,7 +81,7 @@ module ActiveReporting
     #
     # @return [Array]
     def group_by_statement_with_rename(with_identifier: true)
-      return [name] if type == Dimension::TYPES[:degenerate]
+      return [degenerate_fragment] if type == Dimension::TYPES[:degenerate]
 
       group = [name]
       group << "#{name}_identifier" if with_identifier

--- a/lib/active_reporting/reporting_dimension.rb
+++ b/lib/active_reporting/reporting_dimension.rb
@@ -75,6 +75,19 @@ module ActiveReporting
       group
     end
 
+    # Fragments of a group by clause for queries that use the dimension, using
+    # the renamed label. Note that we always rename here, even if the fragment
+    # is degenerate (aka if it is not a foreign key)
+    #
+    # @return [Array]
+    def group_by_statement_with_rename(with_identifier: true)
+      return [name] if type == Dimension::TYPES[:degenerate]
+
+      group = [name]
+      group << "#{name}_identifier" if with_identifier
+      group
+    end
+
     # Fragment of an order by clause for queries that sort by the dimension
     #
     # @return [String]

--- a/lib/active_reporting/reporting_dimension.rb
+++ b/lib/active_reporting/reporting_dimension.rb
@@ -40,30 +40,6 @@ module ActiveReporting
       ss
     end
 
-    # Fragments of a select statement for queries that use the dimension
-    # but where we always want to rename, even if the fragment is degenerate
-    # (aka if it is not a foreign key)
-    #
-    # @return [Array]
-    def select_statement_always_rename(with_identifier: true)
-      return [name] if type == Dimension::TYPES[:degenerate]
-      ss = ["#{label_fragment} AS #{name}"]
-      ss << "#{identifier_fragment} AS #{name}_identifier" if with_identifier
-      ss
-    end
-
-    # Fragment of a select statement for queries that use a dimension
-    # but without renaming returned columnns with 'AS'
-    #
-    # @return [ARRAY]
-    def select_statement_no_rename(with_identifier: true)
-      return [name] if type == Dimension::TYPES[:degenerate]
-
-      ss = ["#{name}"]
-      ss << "#{name}_identifier" if with_identifier
-      ss
-    end
-
     # Fragments of a group by clause for queries that use the dimension
     #
     # @return [Array]
@@ -76,7 +52,7 @@ module ActiveReporting
     end
 
     # Fragments of a group by clause for queries that use the dimension, using
-    # the renamed label. Note that we always rename here, even if the fragment
+    # the renamed label. Note that we do not rename the fragment if it
     # is degenerate (aka if it is not a foreign key)
     #
     # @return [Array]

--- a/lib/active_reporting/version.rb
+++ b/lib/active_reporting/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveReporting
-  VERSION = '0.6.1'
+  VERSION = '0.6.2'
 end

--- a/lib/active_reporting/version.rb
+++ b/lib/active_reporting/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveReporting
-  VERSION = '0.6.24'
+  VERSION = '0.7.0'
 end

--- a/lib/active_reporting/version.rb
+++ b/lib/active_reporting/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveReporting
-  VERSION = '0.6.2'
+  VERSION = '0.6.3'
 end

--- a/lib/active_reporting/version.rb
+++ b/lib/active_reporting/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveReporting
-  VERSION = '0.7.0'
+  VERSION = '0.7.3'
 end

--- a/lib/active_reporting/version.rb
+++ b/lib/active_reporting/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveReporting
-  VERSION = '0.6.20'
+  VERSION = '0.6.24'
 end

--- a/lib/active_reporting/version.rb
+++ b/lib/active_reporting/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveReporting
-  VERSION = '0.6.3'
+  VERSION = '0.6.20'
 end


### PR DESCRIPTION
This PR refactors how we construct the custom query required for performing SUM calculations. The way the query is built is now simpler, and ensures that we are using _all_ elements of the original query in our reconstructed query.