### PR TITLE
Update to remove to_hash deprecation for ActiveRecord::Result

### DIFF
--- a/lib/active_reporting/report.rb
+++ b/lib/active_reporting/report.rb
@@ -36,7 +36,7 @@ module ActiveReporting
     private ######################################################################
 
     def build_data
-      @data = model.connection.exec_query(statement).to_hash
+      @data = model.connection.exec_query(statement).to_a
       apply_dimension_callbacks
       @data
     end


### PR DESCRIPTION
This is a patch to fix the following deprecation,

> DEPRECATION WARNING: `ActiveRecord::Result#to_hash` has been renamed to `to_a`. `to_hash` is deprecated and will be removed in Rails 6.1. (called from build_data at /Users/peerallan/src/github.com/clio/grow/vendor/cache/active_reporting-961bf09607a3/lib/active_reporting/report.rb:39)  

This is meant as a temporary fix until we can update this fork to be inline with upstream.
